### PR TITLE
Access to self._brightness exception

### DIFF
--- a/light.py
+++ b/light.py
@@ -78,6 +78,7 @@ class PlejdLight(Light, RestoreEntity):
     def __init__(self, name, identity):
         self._name = name
         self._id = identity
+        self._brightness = None
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()


### PR DESCRIPTION
Access to self._brightness was accessed before it has been declarated causing an exception in brightness method.

Solves issues #35 