### PR TITLE
manifest: add patch version to the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plejd",
   "name": "Plejd",
-  "version": "1.0",
+  "version": "1.0.0",
   "documentation": "https://github.com/klali/ha-plejd",
   "requirements": [ "dbus-next", "cryptography" ],
   "dependencies": [],


### PR DESCRIPTION
Starting from [2021.6](https://www.home-assistant.io/blog/2021/06/02/release-20216/#other-breaking-changes) it's required to to also have the patch number
included in in the version in the manifest.

This fixes the error below when trying to reload the server:
Error: Platform error light.plejd - Integration 'plejd' not found.

(This is related to #42 as well).

Signed-off-by: Joakim Bech <joakim.bech@gmail.com>