### PR TITLE
Fix typo causing NameError

### DIFF
--- a/custom_components/plejd/light.py
+++ b/custom_components/plejd/light.py
@@ -439,7 +439,7 @@ async def plejd_auth(key, char):
         chal = await char.call_read_value({})
         r = plejd_chalresp(key, chal)
         await char.call_write_value(r, {})
-    except DbusError as e:
+    except DBusError as e:
         _LOGGER.warning("Plejd authentication errored: %s" % (str(e)))
         return False
     return True


### PR DESCRIPTION
Fix typo in light.py causing "NameError: Name 'DbusError' not defined"