### PR TITLE
fix color mode deprecation warning

### DIFF
--- a/custom_components/plejd/light.py
+++ b/custom_components/plejd/light.py
@@ -17,7 +17,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.components.light import (ATTR_BRIGHTNESS, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, LightEntity)
+from homeassistant.components.light import (ATTR_BRIGHTNESS, PLATFORM_SCHEMA, LightEntity, ColorMode )
 from homeassistant.const import CONF_NAME, CONF_DEVICES, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, STATE_ON
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
@@ -121,8 +121,12 @@ class PlejdLight(LightEntity, RestoreEntity):
             return None
 
     @property
-    def supported_features(self):
-        return SUPPORT_BRIGHTNESS
+    def supported_color_modes(self):
+        return { ColorMode.BRIGHTNESS }
+
+    @property
+    def color_mode(self):
+        return ColorMode.BRIGHTNESS
 
     @property
     def unique_id(self):


### PR DESCRIPTION
Warnings in home assistant log:

```
WARNING (MainThread) [homeassistant.components.light] None (<class 'custom_components.plejd.light.PlejdLight'>) does not set supported color modes, this will stop working in Home Assistant Core 2025.3, please report it to the author of the 'plejd' custom integration
WARNING (MainThread) [homeassistant.components.light] Entity None (<class 'custom_components.plejd.light.PlejdLight'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <LightEntityFeature: 1> and color modes, please report it to the author of the 'plejd' custom integration and reference https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
```

fixes #66 